### PR TITLE
feat: added label color and separator selection

### DIFF
--- a/src/components/basic/AddNewField.vue
+++ b/src/components/basic/AddNewField.vue
@@ -17,6 +17,7 @@ const field = ref<BasicTool>({
   main: false,
   type: attributes.types[0].value as BasicTool['type'],
   underline: true,
+  color: 'default',
 })
 
 const open = ref(false)
@@ -39,12 +40,17 @@ function reset() {
   field.value.main = false
   field.value.type = attributes.types[0].value as BasicTool['type']
   field.value.underline = true
+  field.value.color = 'default'
 }
 
 watch(
   () => field.value.type,
   (newType) => {
     if (newType === 'hyperlink' && typeof field.value.underline === 'undefined') {
+      field.value.underline = true
+    }
+    else if (newType !== 'hyperlink' && typeof field.value.color === 'undefined') {
+      field.value.color = 'default'
       field.value.underline = true
     }
   },
@@ -101,10 +107,35 @@ watch(
             />
           </UiFieldFormItem>
           <UiFieldFormItem>
-            <UiCheckbox
-              v-model:checked="field.underline"
-              label="Display with underline"
-            />
+            <div class="flex items-center gap-2">
+              <UiCheckbox
+                id="underline-checkbox"
+                v-model:checked="field.underline"
+              />
+              <label for="underline-checkbox">Display with underline</label>
+            </div>
+          </UiFieldFormItem>
+        </template>
+        <template v-else>
+          <UiFieldFormItem label="Color">
+            <UiSelect v-model="field.color">
+              <UiSelectTrigger>
+                <UiSelectValue />
+              </UiSelectTrigger>
+              <UiSelectContent>
+                <UiSelectGroup>
+                  <UiSelectItem value="default">
+                    Default
+                  </UiSelectItem>
+                  <UiSelectItem value="main">
+                    Main Color
+                  </UiSelectItem>
+                  <UiSelectItem value="secondary">
+                    Secondary Color
+                  </UiSelectItem>
+                </UiSelectGroup>
+              </UiSelectContent>
+            </UiSelect>
           </UiFieldFormItem>
         </template>
       </UiFieldForm>

--- a/src/components/basic/FormItem.vue
+++ b/src/components/basic/FormItem.vue
@@ -19,17 +19,19 @@ function onRemoveField() {
   installed.value.tools.basic.splice(itemIndex, 1)
 }
 
-watch(
-  () => item.value?.type,
-  (newType) => {
-    if (newType === 'hyperlink') {
+watchEffect(() => {
+  if (item.value) {
+    if (item.value.type === 'hyperlink') {
       if (item.value.title === undefined)
         item.value.title = ''
       if (item.value.underline === undefined)
         item.value.underline = false
     }
-  },
-)
+    else if (item.value.color === undefined) {
+      item.value.color = 'default'
+    }
+  }
+})
 </script>
 
 <template>
@@ -94,10 +96,38 @@ watch(
                         />
                       </UiFieldFormItem>
                       <UiFieldFormItem class="col-span-2">
-                        <UiCheckbox
-                          v-model="item.underline"
-                          label="Display with underline"
-                        />
+                        <div class="flex items-center gap-2">
+                          <UiCheckbox
+                            :id="`underline-checkbox-${item.id}`"
+                            v-model:checked="item.underline"
+                          />
+                          <label :for="`underline-checkbox-${item.id}`">Display with underline</label>
+                        </div>
+                      </UiFieldFormItem>
+                    </template>
+                    <template v-else>
+                      <UiFieldFormItem
+                        label="Color"
+                        class="col-span-2"
+                      >
+                        <UiSelect v-model="item.color">
+                          <UiSelectTrigger>
+                            <UiSelectValue />
+                          </UiSelectTrigger>
+                          <UiSelectContent>
+                            <UiSelectGroup>
+                              <UiSelectItem value="default">
+                                Default
+                              </UiSelectItem>
+                              <UiSelectItem value="main">
+                                Main Color
+                              </UiSelectItem>
+                              <UiSelectItem value="secondary">
+                                Secondary Color
+                              </UiSelectItem>
+                            </UiSelectGroup>
+                          </UiSelectContent>
+                        </UiSelect>
                       </UiFieldFormItem>
                     </template>
                   </UiFieldForm>

--- a/src/components/options/Form.vue
+++ b/src/components/options/Form.vue
@@ -76,6 +76,13 @@ const fontSize = computed({
   },
 })
 
+const labelSeparator = computed({
+  get: () => options.value.labelSeparator || 'none',
+  set: (val: string) => {
+    options.value.labelSeparator = val === 'none' ? '' : val
+  },
+})
+
 const jobSeparator = computed({
   get: () => options.value.jobSeparator,
   set: (val: string) => {
@@ -217,6 +224,24 @@ const jobSeparator = computed({
             <UiSelectGroup>
               <UiSelectItem
                 v-for="item in attributes.separator.options"
+                :key="item.value"
+                :value="item.value"
+              >
+                {{ item.label }}
+              </UiSelectItem>
+            </UiSelectGroup>
+          </UiSelectContent>
+        </UiSelect>
+      </UiFieldFormItem>
+      <UiFieldFormItem label="Label separator">
+        <UiSelect v-model="labelSeparator">
+          <UiSelectTrigger>
+            <UiSelectValue placeholder="Select a value" />
+          </UiSelectTrigger>
+          <UiSelectContent>
+            <UiSelectGroup>
+              <UiSelectItem
+                v-for="item in attributes.labelSeparator.options"
                 :key="item.value"
                 :value="item.value"
               >

--- a/src/components/templates/components/main/Field.vue
+++ b/src/components/templates/components/main/Field.vue
@@ -18,12 +18,25 @@ interface Props {
   font?: object
   labelColor?: string
   textColor?: string
+  analyticTag?: string
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
   type: 'td',
   display: 'block',
   showLabel: true,
+})
+
+const { options } = useSignatures()
+
+const computedTextColor = computed(() => {
+  if (props.model.color === 'main')
+    return options.value.mainColor
+
+  if (props.model.color === 'secondary')
+    return options.value.secondaryColor
+
+  return props.textColor || '#010101'
 })
 </script>
 
@@ -43,11 +56,20 @@ withDefaults(defineProps<Props>(), {
           style="padding-right: 0px; font-weight: 600"
           v-bind="$attrs"
           :style="{ color: labelColor }"
-        >{{ model.label }}:&nbsp;&nbsp;</span>
+        >{{ model.label }}{{ options?.labelSeparator ?? ':' }}&nbsp;&nbsp;</span>
         <Base.Link
           v-if="model.type !== 'text'"
-          v-bind="getAnchorAttrs(model, textColor || '#010101', enableAnalytics, analyticTag)"
-          :style="{ textDecoration: model.underline === false ? 'none' : 'underline' }"
+          v-bind="
+            getAnchorAttrs(model.type === 'hyperlink' ? { ...model, type: 'link' } : model, {
+              color: computedTextColor,
+              enableAnalytics,
+              analyticTag,
+            })
+          "
+          :style="{
+            textDecoration:
+              model.type === 'hyperlink' && model.underline ? 'underline' : 'none !important',
+          }"
           :title="model.title"
         >
           <template v-if="model.type === 'hyperlink'">
@@ -59,9 +81,11 @@ withDefaults(defineProps<Props>(), {
         </Base.Link>
         <span
           v-if="model.type === 'text'"
-          :style="{ color: textColor || '#010101' }"
+          :style="{ color: computedTextColor }"
           v-bind="$attrs"
-        >{{ model.value }}</span>
+        >{{
+          model.value
+        }}</span>
       </p>
     </td>
   </tr>

--- a/src/components/templates/components/main/JobFields.vue
+++ b/src/components/templates/components/main/JobFields.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 
-import type { BasicTool } from '~/composables/signatures/types'
+import type { BasicTool } from '@/composables/signatures/types'
 
 import * as Base from '@/components/templates/components/base'
 
@@ -21,11 +21,23 @@ interface Props {
   separatorStyle?: HTMLAttributes['style']
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
   type: 'td',
   display: 'block',
   showLabel: true,
 })
+
+const { options } = useSignatures()
+
+function getComputedTextColor(item: BasicTool) {
+  if (item.color === 'main')
+    return options.value.mainColor
+
+  if (item.color === 'secondary')
+    return options.value.secondaryColor
+
+  return props.textColor || '#000'
+}
 </script>
 
 <template>
@@ -51,16 +63,16 @@ withDefaults(defineProps<Props>(), {
               style="padding-right: 0px; font-weight: 600"
               v-bind="$attrs"
               :style="{ color: labelColor }"
-            >{{ i.label }}:&nbsp;&nbsp;</span>
+            >{{ i.label }}{{ options?.labelSeparator ?? ':' }}&nbsp;&nbsp;</span>
             <Base.Link
               v-if="i.type !== 'text'"
-              v-bind="getAnchorAttrs(i, textColor || '#000')"
+              v-bind="getAnchorAttrs(i, { color: getComputedTextColor(i) })"
             >
               {{ i.value }}
             </Base.Link>
             <span
               v-if="i.type === 'text'"
-              :style="{ color: textColor || '#000' }"
+              :style="{ color: getComputedTextColor(i) }"
               v-bind="$attrs"
             >{{ i.value }}</span>
           </span>
@@ -77,20 +89,18 @@ withDefaults(defineProps<Props>(), {
             style="padding-right: 0px; font-weight: 600"
             v-bind="$attrs"
             :style="{ color: labelColor }"
-          >{{ i.label }}:&nbsp;&nbsp;</span>
+          >{{ i.label }}{{ options?.labelSeparator ?? ':' }}&nbsp;&nbsp;</span>
           <Base.Link
             v-if="i.type !== 'text'"
-            v-bind="getAnchorAttrs(i, textColor || '#000')"
+            v-bind="getAnchorAttrs(i, { color: getComputedTextColor(i) })"
           >
             {{ i.value }}
           </Base.Link>
           <span
             v-if="i.type === 'text'"
-            :style="{ color: textColor || '#000' }"
+            :style="{ color: getComputedTextColor(i) }"
             v-bind="$attrs"
-          >{{
-            i.value
-          }}</span>
+          >{{ i.value }}</span>
         </p>
       </template>
     </td>

--- a/src/components/templates/components/utils/index.ts
+++ b/src/components/templates/components/utils/index.ts
@@ -4,34 +4,34 @@ import type { BasicTool } from '@/composables/signatures/types'
 
 import { normalizeUrl } from '@/utils'
 
+interface AnchorAttrsOptions {
+  color: string
+  enableAnalytics?: boolean
+  analyticTag?: string
+}
+
 export function getAnchorAttrs(
   tool: BasicTool,
-  textColor: string,
+  options: AnchorAttrsOptions,
 ): AnchorHTMLAttributes | undefined {
+  const attrs: Record<string, any> = {
+    style: {
+      color: options.color,
+    },
+  }
+
+  let href = tool.value
+
   if (tool.type === 'link') {
-    return {
-      href: normalizeUrl(tool.value),
-      style: {
-        color: textColor,
-      },
-    }
+    href = normalizeUrl(href)
+  }
+  else if (tool.type === 'email') {
+    href = `mailto:${href}`
+  }
+  else if (tool.type === 'phone') {
+    href = `tel:${href}`
   }
 
-  if (tool.type === 'email') {
-    return {
-      href: `mailto:${tool.value}`,
-      style: {
-        color: textColor,
-      },
-    }
-  }
-
-  if (tool.type === 'phone') {
-    return {
-      href: `tel:${tool.value}`,
-      style: {
-        color: textColor,
-      },
-    }
-  }
+  attrs.href = href
+  return attrs
 }

--- a/src/composables/signatures/types/index.ts
+++ b/src/composables/signatures/types/index.ts
@@ -110,6 +110,7 @@ export interface BasicTool {
   type: Basic
   value: string
   title?: string
+  color?: 'main' | 'secondary' | 'default'
   underline?: boolean
 }
 
@@ -122,6 +123,7 @@ export interface OptionsTool {
   fontFamily: string
   fontSize: number
   jobSeparator: string
+  labelSeparator?: string
   mainColor: string
   secondaryColor: string
   column1Width?: number

--- a/src/composables/signatures/useSignatures.ts
+++ b/src/composables/signatures/useSignatures.ts
@@ -99,6 +99,7 @@ const isSecondColorAvailable = computed(() => {
     'SignatureTemplate6',
     'SignatureTemplate8',
     'SignatureTemplate9',
+    'SignatureTemplate10',
   ]
   return available.includes(installed.value.name)
 })

--- a/src/data/attributes.ts
+++ b/src/data/attributes.ts
@@ -49,6 +49,13 @@ export const attributes = {
       { label: 'New line', value: 'br' },
     ],
   },
+  labelSeparator: {
+    options: [
+      { label: ':', value: ':' },
+      { label: '-', value: ' -' },
+      { label: 'Blank', value: 'none' },
+    ],
+  },
   types: [
     { label: 'Text', value: 'text' },
     { label: 'Email', value: 'email' },


### PR DESCRIPTION
## Summary by Sourcery

Add support for customizable field text colors and label separators with corresponding UI controls and template updates

New Features:
- Add color attribute to BasicTool and UI controls for selecting default, main, or secondary text colors in form fields
- Introduce label separator selection in options and apply customizable separators in signature templates

Enhancements:
- Refactor initialization logic with watchEffect for default field properties
- Compute dynamic text color in Field and JobFields components based on selected color options
- Update getAnchorAttrs to accept a color and analytics options object and unify href assignment

Documentation:
- Add labelSeparator options to attributes data for configuring label separators

Chores:
- Expand useSignatures availability list to include SignatureTemplate10